### PR TITLE
mkdir_if_necessary

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -23,6 +23,12 @@ function symlink_files(dir, ext)
 	end
 end
 
+function mkdir_if_necessary(dir)
+	if !isdir(dir)
+		mkdir(dir)
+	end
+end
+
 bitsize = Int == Int64 ? 64 : 32
 
 deps = Pkg.dir("SFML")*"/deps"
@@ -41,10 +47,10 @@ cd(deps)
 		download(csfml, "csfml.tar.gz")
 	end
 
-	mkdir("sfml")
+	mkdir_if_necessary("sfml")
 	run(`tar -xzf sfml.tar.gz -C sfml --strip-components=1`)
 
-	mkdir("csfml")
+	mkdir_if_necessary("csfml")
 	run(`tar -xzf csfml.tar.gz -C csfml --strip-components=1`)
 
 	symlink_files("$deps/csfml/lib", "2.2.0.dylib")
@@ -75,10 +81,10 @@ end
 		download(csfml, "csfml.tar.bz2")
 	end
 
-	mkdir("sfml")
+	mkdir_if_necessary("sfml")
 	run(`tar -xzf sfml.tar.gz -C sfml --strip-components=1`)
 
-	mkdir("csfml")
+	mkdir_if_necessary("csfml")
 	run(`tar -xjf csfml.tar.bz2 -C csfml --strip-components=1`)
 
 	symlink_files("$deps/csfml/lib", "so.2.2.0")


### PR DESCRIPTION
For some reason, when I tried to update SFML.jl this morning, I already had the directories SFML/deps/sfml/ and and SFML/deps/csfml/, so the mkdir() commands failed and the build process aborted early. This patch checks for their existence first. Perhaps it would be better to remove them and recreate them instead of skipping over the mkdir, just to make sure we have a clean slate, but at least this got past the error.

