### PR TITLE
Use clamp! instead of clamp in Color()

### DIFF
--- a/src/julia/Graphics/color.jl
+++ b/src/julia/Graphics/color.jl
@@ -5,12 +5,12 @@ type Color
     a::UInt8
 
     function Color(r::Integer, g::Integer, b::Integer)
-        clamp(r, 0, 255); clamp(g, 0, 255); clamp(b, 0, 255);
+        clamp!(r, 0, 255); clamp!(g, 0, 255); clamp!(b, 0, 255);
         new(UInt8(r), UInt8(g), UInt8(b), UInt8(255))
     end
 
     function Color(r::Integer, g::Integer, b::Integer, a::Integer)
-        clamp(r, 0, 255); clamp(g, 0, 255); clamp(b, 0, 255); clamp(a, 0, 255)
+        clamp!(r, 0, 255); clamp!(g, 0, 255); clamp!(b, 0, 255); clamp!(a, 0, 255)
         new(UInt8(r), UInt8(g), UInt8(b), UInt8(a))
     end
 end


### PR DESCRIPTION
Calling Color() with arguments outside the range 0:255 results in ``InexactError`` while converting to ``UInt8``. This fix uses ``clamp!`` instead of ``clamp`` to avoid this.