### PR TITLE
Make sure 'gcc.exe' exists not just 'bin'

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -116,8 +116,8 @@ end
 end
 
 @windows_only begin
-    RPMbindir = Pkg.dir("WinRPM","deps","usr","$(Sys.ARCH)-w64-mingw32","sys-root","mingw","bin")
-    if !isdir(RPMbindir)
+    GCCPath = Pkg.dir("WinRPM","deps","usr","$(Sys.ARCH)-w64-mingw32","sys-root","mingw","bin","gcc.exe")
+    if !isfile(GCCPath)
         println("Installing gcc...")
         WinRPM.install("gcc")
     end


### PR DESCRIPTION
It happened on my machine that `WinRPM\deps\usr\x86_64-w64-mingw32\sys-root\mingw\bin` directory existed without the `gcc` package being actually installed in `WinRPM`. Therefore, building `SFML` failed with the following error
```
julia> Pkg.add("SFML")
INFO: Installing SFML v0.1.0
INFO: Building WinRPM
INFO: Downloading https://cache.julialang.org/http://download.opensuse.org/repositories/windows:/mingw:/win32/openSUSE_13.2/repodata/repomd.xml
INFO: Downloading https://cache.julialang.org/http://download.opensuse.org/repositories/windows:/mingw:/win64/openSUSE_13.2/repodata/repomd.xml
INFO: Building SFML
Downloading SFML and CSFML
Cloning into 'sfml-binaries'...
remote: Counting objects: 133, done.
remote: Total 133 (delta 0), reused 0 (delta 0), pack-reused 133
Receiving objects: 100% (133/133), 7.92 MiB | 664.00 KiB/s, done.
Resolving deltas: 100% (56/56), done.
Checking connectivity... done.
ERROR: LoadError: could not spawn `gcc '-IE:\code\.julia\v0.4\WinRPM\deps\usr\x86_64-w64-mingw32\sys-root\mingw\include' '-IE:\code\.julia\v0.4\SFML\deps\sfml-binaries\csfml\include' -c 'Window\event.c' 'Network\Network.c' 'Graphics\shader.c'`: no such file or directory (ENOENT)
 in _jl_spawn at process.jl:262
while loading E:\code\.julia\v0.4\SFML\src\c\createlib.jl, in expression starting on line 21
================================[ ERROR: SFML ]=================================

LoadError: failed process: Process(`julia createlib.jl`, ProcessExited(1)) [1]
while loading E:\code\.julia\v0.4\SFML\deps\build.jl, in expression starting on line 128

================================================================================

========================================================[ BUILD ERRORS ]========================================================

WARNING: SFML had build errors.

 - packages with build errors remain installed in E:\code\.julia\v0.4
 - build the package(s) and all dependencies with `Pkg.build("SFML")`
 - build a single package by running its `deps/build.jl` script

================================================================================================================================
INFO: Package database updated
```

Afterwards, manually running
```
julia> import WinRPM

julia> WinRPM.install("gcc")
```
fixed the problem.
```
julia> Pkg.build("SFML")
INFO: Building WinRPM
INFO: Downloading https://cache.julialang.org/http://download.opensuse.org/repositories/windows:/mingw:/win32/openSUSE_13.2/repodata/repomd.xml
INFO: Downloading https://cache.julialang.org/http://download.opensuse.org/repositories/windows:/mingw:/win64/openSUSE_13.2/repodata/repomd.xml
INFO: Building SFML
Downloading SFML and CSFML
Cloning into 'sfml-binaries'...
remote: Counting objects: 133, done.
remote: Total 133 (delta 0), reused 0 (delta 0), pack-reused 133
Receiving objects: 100% (133/133), 7.92 MiB | 660.00 KiB/s, done.
Resolving deltas: 100% (56/56), done.
Checking connectivity... done.
Successfully built SFML.jl!
```

This commit checks for the existence of `gcc.exe` under `bin` to avoid build failure under this scenario.