### PR TITLE
Set yes=true for gcc installation on Windows

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -119,7 +119,7 @@ end
     GCCPath = Pkg.dir("WinRPM","deps","usr","$(Sys.ARCH)-w64-mingw32","sys-root","mingw","bin","gcc.exe")
     if !isfile(GCCPath)
         println("Installing gcc...")
-        WinRPM.install("gcc")
+        WinRPM.install("gcc",yes=true)
     end
 
     cd(deps)


### PR DESCRIPTION
Occasionally, WinRPM will ask whether to continue with gcc install on Windows, with 'no' being the default. This results in build failure as seen here
```
julia> Pkg.build("SFML")
INFO: Building WinRPM
INFO: Downloading https://cache.julialang.org/http://download.opensuse.org/repos
itories/windows:/mingw:/win32/openSUSE_13.2/repodata/repomd.xml
INFO: Downloading https://cache.julialang.org/http://download.opensuse.org/repos
itories/windows:/mingw:/win64/openSUSE_13.2/repodata/repomd.xml
INFO: Building SFML
Installing gcc...
INFO: Multiple package candidates found for mingw64-unistd-pthread-devel, picking newest.
INFO: Packages to install: libwinpthread1, winpthreads-devel, libgmp10, binutils, runtime, headers, libmpc3, libmpfr4, cpp, gcc
Continue with install [y/N]? INFO: Complete
Downloading SFML and CSFML
Cloning into 'sfml-binaries'...
remote: Counting objects: 133, done.
remote: Total 133 (delta 0), reused 0 (delta 0), pack-reused 133
Receiving objects: 100% (133/133), 7.99 MiB | 356.00 KiB/s, done.
Resolving deltas: 100% (56/56), done.
Checking connectivity... done.
ERROR: LoadError: could not spawn `gcc '-IC:\Users\Lab\.julia\v0.4\WinRPM\deps\usr\x86_64-w64-mingw32\sys-root\mingw\include' '-IC:\Users\Lab\.julia\v0.4\SFML\deps\sfml-binaries\csfml\include' -c 'Window\event.c' 'Network\Network.c' 'Graphics\shader.c'`: no such file or directory (ENOENT)
 in _jl_spawn at process.jl:262
while loading C:\Users\Lab\.julia\v0.4\SFML\src\c\createlib.jl, in expression starting on line 21
================================[ ERROR: SFML]=================================


LoadError: failed process: Process(`'C:\Julia-0.4.5\bin\julia' createlib.jl`, ProcessExited(1)) [1]
while loading C:\Users\Lab\.julia\v0.4\SFML\deps\build.jl, in expression starting on line 147

================================================================================


================================[ BUILD ERRORS]================================


WARNING: SFML had build errors.

 - packages with build errors remain installed in C:\Users\Lab\.julia\v0.4
 - build the package(s) and all dependencies with `Pkg.build("SFML")`
 - build a single package by running its `deps/build.jl` script

================================================================================
```

This commit sets `yes=true` while installing gcc to fix this issue.