### PR TITLE
Small Improvements to Sound and SoundBuffer

### DIFF
--- a/src/exports.jl
+++ b/src/exports.jl
@@ -188,6 +188,7 @@ export SoundBufferRecorder
 export start
 export get_sample_rate
 export get_buffer
+export get_playing_offset
 export SoundStatus
 export upload
 export download

--- a/src/julia/Audio/sound.jl
+++ b/src/julia/Audio/sound.jl
@@ -75,3 +75,9 @@ end
 function get_volume(sound::Sound)
     return Real(ccall((:sfSound_getVolume, libcsfml_audio), Cfloat, (Ptr{Void},), sound.ptr))
 end
+
+function get_playing_offset(sound::Sound)
+  return ccall((:sfSound_getPlayingOffset, libcsfml_audio), Time,
+                    (Ptr{Void},), sound.ptr)
+end
+

--- a/src/julia/Audio/sound.jl
+++ b/src/julia/Audio/sound.jl
@@ -49,7 +49,7 @@ function set_buffer(sound::Sound, sound_buffer::SoundBuffer)
 end
 
 function get_buffer(sound::Sound)
-    return SoundBuffer(ccall((:sfSound_getBuffer, libcsfml_audio), Void, (Ptr{Void},), sound.ptr))
+    return SoundBuffer(ccall((:sfSound_getBuffer, libcsfml_audio), Ptr{Void}, (Ptr{Void},), sound.ptr))
 end
 
 function set_loop(sound::Sound, loop::Bool)

--- a/src/julia/Audio/soundBuffer.jl
+++ b/src/julia/Audio/soundBuffer.jl
@@ -12,6 +12,12 @@ function SoundBuffer(filename::AbstractString)
     SoundBuffer(ccall((:sfSoundBuffer_createFromFile, libcsfml_audio), Ptr{Void}, (Ptr{Cchar},), filename))
 end
 
+function SoundBuffer(buffer::Array{Int16},samplerate::Int)
+  SoundBuffer(ccall((:sfSoundBuffer_createFromSamples, libcsfml_audio),
+                    Ptr{Void}, (Ptr{Int16}, UInt64, UInt, UInt),
+                    buffer,size(buffer,1),size(buffer,2),samplerate))
+end
+
 function copy(buffer::SoundBuffer)
     return SoundBuffer(ccall((:sfSoundBuffer_copy, libcsfml_audio), Ptr{Void}, (Ptr{Void},), buffer.ptr))
 end

--- a/src/julia/Audio/soundBuffer.jl
+++ b/src/julia/Audio/soundBuffer.jl
@@ -44,5 +44,5 @@ function save_to_file(buffer::SoundBuffer, filename::AbstractString)
 end
 
 function get_duration(buffer::SoundBuffer)
-    return ccall((:sfSoundBUffer_getDuration, libcsfml_audio), Time, (Ptr{Void},), buffer.ptr)
+    return ccall((:sfSoundBuffer_getDuration, libcsfml_audio), Time, (Ptr{Void},), buffer.ptr)
 end


### PR DESCRIPTION
This improves the functionality of the Sound and SoundBuffer objects, squashing a few runtime errors I found in the process of using these types. Specifically:

- SoundBuffer can now be initialized from array data
- If a Sound is playing, you can get the current position within the buffer using get_playing_offset

The errors I fixed were typos in the implementation of get_duration (in SoundBuffer) and get_buffer (in Sound).